### PR TITLE
Fix fee calculation in bitcoind client

### DIFF
--- a/crates/esploda/src/bitcoind/tx.rs
+++ b/crates/esploda/src/bitcoind/tx.rs
@@ -210,9 +210,10 @@ impl Transaction {
         block_height: u32,
         previous_outputs: Vec<TxOut>,
     ) -> crate::esplora::Transaction {
-        let fee: Decimal = previous_outputs.iter().map(|txo| txo.value).sum()
-            - self.outputs.iter().map(|txo| txo.value).sum();
+        let prev_outputs: Decimal = previous_outputs.iter().map(|txo| txo.value).sum();
+        let outputs: Decimal = self.outputs.iter().map(|txo| txo.value).sum();
 
+        let fee = prev_outputs - outputs;
         assert!(!fee.is_sign_negative(), "Fee must never be negative");
 
         let mut previous_outputs = previous_outputs.into_iter();

--- a/crates/esploda/src/bitcoind/tx.rs
+++ b/crates/esploda/src/bitcoind/tx.rs
@@ -200,7 +200,9 @@ impl Transaction {
     ///
     /// # Panics
     ///
-    /// Asserts that `previous_outputs` and `self.inputs` have the same number of non-coinbase TXOs.
+    /// - Asserts that the computed `fee` is not negative.
+    /// - Asserts that `previous_outputs` and `self.inputs` have the same number of non-coinbase
+    ///   TXOs.
     ///
     /// [`esplora::Transaction`]: crate::esplora::Transaction
     pub fn into_esplora(
@@ -208,7 +210,11 @@ impl Transaction {
         block_height: u32,
         previous_outputs: Vec<TxOut>,
     ) -> crate::esplora::Transaction {
-        let fee = previous_outputs.iter().map(|txo| txo.value).sum();
+        let fee = previous_outputs.iter().map(|txo| txo.value).sum()
+            - self.outputs.iter().map(|txo| txo.value).sum();
+
+        assert!(!fee.is_negative(), "Fee must never be negative");
+
         let mut previous_outputs = previous_outputs.into_iter();
         let inputs = self
             .inputs

--- a/crates/esploda/src/bitcoind/tx.rs
+++ b/crates/esploda/src/bitcoind/tx.rs
@@ -1,9 +1,9 @@
 use crate::esplora::{TxIn, TxOut};
-use bitcoin::{hash_types::TxMerkleNode, locktime::absolute::LockTime, pow::CompactTarget};
 use bitcoin::{BlockHash, ScriptBuf, Sequence, Txid, Witness};
+use bitcoin::{hash_types::TxMerkleNode, locktime::absolute::LockTime, pow::CompactTarget};
 use chrono::{DateTime, Utc};
 use data_encoding::HEXLOWER;
-use rust_decimal::{prelude::FromPrimitive as _, Decimal};
+use rust_decimal::{Decimal, prelude::FromPrimitive as _};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::str::FromStr;
@@ -210,10 +210,10 @@ impl Transaction {
         block_height: u32,
         previous_outputs: Vec<TxOut>,
     ) -> crate::esplora::Transaction {
-        let fee = previous_outputs.iter().map(|txo| txo.value).sum()
+        let fee: Decimal = previous_outputs.iter().map(|txo| txo.value).sum()
             - self.outputs.iter().map(|txo| txo.value).sum();
 
-        assert!(!fee.is_negative(), "Fee must never be negative");
+        assert!(!fee.is_sign_negative(), "Fee must never be negative");
 
         let mut previous_outputs = previous_outputs.into_iter();
         let inputs = self

--- a/crates/esploda/src/bitcoind/tx.rs
+++ b/crates/esploda/src/bitcoind/tx.rs
@@ -1,9 +1,9 @@
 use crate::esplora::{TxIn, TxOut};
-use bitcoin::{BlockHash, ScriptBuf, Sequence, Txid, Witness};
 use bitcoin::{hash_types::TxMerkleNode, locktime::absolute::LockTime, pow::CompactTarget};
+use bitcoin::{BlockHash, ScriptBuf, Sequence, Txid, Witness};
 use chrono::{DateTime, Utc};
 use data_encoding::HEXLOWER;
-use rust_decimal::{Decimal, prelude::FromPrimitive as _};
+use rust_decimal::{prelude::FromPrimitive as _, Decimal};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::str::FromStr;


### PR DESCRIPTION
When using the bitcoind client for transaction resolution, the fee calculation was completely wrong. Every previous output was considered the fee.

The fix is calculating the fee as the difference between the transaction outputs and the previous outputs.